### PR TITLE
Allow for passing non-string arguments

### DIFF
--- a/lib/sudo.js
+++ b/lib/sudo.js
@@ -21,7 +21,9 @@ function sudo(command, options) {
     args.push.apply(args, command);
 
     // The binary is the first non-dashed parameter to sudo
-    var bin = command.filter(function (i) { return i.indexOf('-') !== 0; })[0];
+    var bin = command.filter(function (i) {
+        return typeof i === 'string' && i.indexOf('-') !== 0;
+    })[0];
 
     var options = options || {};
     var spawnOptions = options.spawnOptions || {};


### PR DESCRIPTION
`sudo(['kill', 9, 123]);`